### PR TITLE
Make input field numeric

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,6 +124,7 @@
                 pattern="^\$\d{1,3}(,\d{3})*(\.\d+)?$"
                 data-type="currency"
                 placeholder="Enter a guess..."
+                inputmode="numeric"
               />
             </div>
             <div id="button-container">


### PR DESCRIPTION
RE: #1, this PR makes the input field `numeric` causing it to default to the numpad on mobile keyboards