### PR TITLE
Fix Timezone Issue

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -17,7 +17,7 @@ let warningTimeout;
 */
 
 //The day Costcodle was launched. Used to find game number each day
-const costcodleStartDate = new Date("09/21/2023");
+const costcodleStartDate = new Date(Date.UTC(2023, 8, 21));
 const gameNumber = getGameNumber();
 
 //Elements with event listeners to play the game


### PR DESCRIPTION
The start date for Costcodle was set to September 21, 12AM in the local timezone. This resulted in the GameNumber changing dependent on the local timezone. Ergo, UTC-5 would be on game 494, and UTC+5 would be on game 495, rather than both being on the same game number. By setting the costcodleStartDate to October 21 in UTC+0, this issue is avoided and all users should experience the same game number regardless of local timezone.